### PR TITLE
Add last_passed_index to action feedback

### DIFF
--- a/trajectory_tracker/include/trajectory_tracker/path2d.h
+++ b/trajectory_tracker/include/trajectory_tracker/path2d.h
@@ -287,14 +287,23 @@ public:
   template <typename PATH_TYPE>
   inline void fromMsg(const PATH_TYPE& path, const double in_place_turn_eps = 1.0e-6)
   {
+    std::vector<size_t> dummy_indices;
+    fromMsgWithIndices(path, in_place_turn_eps, dummy_indices);
+  }
+  template <typename PATH_TYPE>
+  inline void fromMsgWithIndices(const PATH_TYPE& path, const double in_place_turn_eps,
+                                 std::vector<size_t>& path_to_msg_indices)
+  {
     clear();
+    path_to_msg_indices.clear();
     bool in_place_turning = false;
     trajectory_tracker::Pose2D in_place_turn_end;
-    for (const auto& pose : path.poses)
+    for (size_t i = 0; i < path.poses.size(); ++i)
     {
-      const trajectory_tracker::Pose2D next(pose);
+      const trajectory_tracker::Pose2D next(path.poses[i]);
       if (empty())
       {
+        path_to_msg_indices.push_back(0);
         push_back(next);
         continue;
       }
@@ -302,9 +311,11 @@ public:
       {
         if (in_place_turning)
         {
+          path_to_msg_indices.push_back(i - 1);
           push_back(in_place_turn_end);
           in_place_turning = false;
         }
+        path_to_msg_indices.push_back(i);
         push_back(next);
       }
       else
@@ -315,6 +326,7 @@ public:
     }
     if (in_place_turning)
     {
+      path_to_msg_indices.push_back(path.poses.size() - 1);
       push_back(in_place_turn_end);
     }
   }

--- a/trajectory_tracker/include/trajectory_tracker/tracker_node.hpp
+++ b/trajectory_tracker/include/trajectory_tracker/tracker_node.hpp
@@ -135,6 +135,7 @@ private:
   double odom_timeout_sec_;
 
   trajectory_tracker::Path2D path_;
+  std::vector<size_t> path_to_msg_indices_;
   std_msgs::msg::Header path_header_;
   bool is_path_updated_;
 
@@ -202,13 +203,14 @@ private:
   bool isControlNeeded() const;
   template <typename ActionClass>
   void computeControl(std::shared_ptr<nav2_util::SimpleActionServer<ActionClass>> action_server);
+  void setFeedback(Action::Feedback& feedback);
+  void setFeedback(ActionWithVelocity::Feedback& feedback);
   template <typename ActionClass>
   bool spinActionServerOnce(std::shared_ptr<nav2_util::SimpleActionServer<ActionClass>> action_server);
   void computeControlNormal();
   void computeControlWithVelocity();
   void publishZeroVelocity();
   void resetLatestStatus();
-
   template <typename MSG_TYPE>
   bool shouldKeepRotation(const MSG_TYPE& msg) const;
 };


### PR DESCRIPTION
Actionのfeedbackで経路追従の途中経過を取得できるようにする。また、msgから内部形式の変換の際にvectorのサイズが変わることがあるので、インデックス変換用のテーブルも追加した。