### PR TITLE
Modify action server behavior

### DIFF
--- a/trajectory_tracker/include/trajectory_tracker/tracker_node.hpp
+++ b/trajectory_tracker/include/trajectory_tracker/tracker_node.hpp
@@ -215,8 +215,8 @@ private:
   void resetLatestStatus();
   template <typename MSG_TYPE>
   bool shouldKeepRotation(const MSG_TYPE& msg) const;
-  void publishReceivedPath(const nav_msgs::msg::Path& path);
-  void publishReceivedPath(const trajectory_tracker_msgs::msg::PathWithVelocity& path);
+  void publishTrackingPath(const nav_msgs::msg::Path& path);
+  void publishTrackingPath(const trajectory_tracker_msgs::msg::PathWithVelocity& path);
   void publishRemainingPath();
 };
 

--- a/trajectory_tracker/include/trajectory_tracker/tracker_node.hpp
+++ b/trajectory_tracker/include/trajectory_tracker/tracker_node.hpp
@@ -32,6 +32,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <condition_variable>
 #include <limits>
 #include <string>
 #include <variant>
@@ -118,7 +119,8 @@ private:
   double tracking_search_range_;
   bool keep_last_rotation_;
   bool is_robot_rotating_on_last_;
-  double action_server_process_rate_sec_;
+  std::chrono::duration<double> action_server_wait_duration_;
+  std::condition_variable action_server_feedback_cv_;
 
   rclcpp::SubscriptionBase::SharedPtr sub_path_;
   rclcpp::SubscriptionBase::SharedPtr sub_path_velocity_;
@@ -127,7 +129,8 @@ private:
   rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr pub_vel_;
   rclcpp::Publisher<trajectory_tracker_msgs::msg::TrajectoryTrackerStatus>::SharedPtr pub_status_;
   rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr pub_tracking_;
-  rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr pub_received_path_;
+  rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr pub_remaining_path_;
+  rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr pub_tracking_path_;
   tf2_ros::Buffer tfbuf_;
   tf2_ros::TransformListener tfl_;
   rclcpp::TimerBase::SharedPtr timer_;
@@ -152,7 +155,6 @@ private:
   trajectory_tracker_msgs::msg::TrajectoryTrackerStatus latest_status_;
   nav_msgs::msg::Path received_path_;
   int64_t unable_to_follow_path_threshold_;
-  int unable_to_follow_path_count_;
 
   struct TrackingResult
   {
@@ -206,13 +208,16 @@ private:
   void setFeedback(Action::Feedback& feedback);
   void setFeedback(ActionWithVelocity::Feedback& feedback);
   template <typename ActionClass>
-  bool spinActionServerOnce(std::shared_ptr<nav2_util::SimpleActionServer<ActionClass>> action_server);
+  bool spinActionServer(std::shared_ptr<nav2_util::SimpleActionServer<ActionClass>> action_server);
   void computeControlNormal();
   void computeControlWithVelocity();
   void publishZeroVelocity();
   void resetLatestStatus();
   template <typename MSG_TYPE>
   bool shouldKeepRotation(const MSG_TYPE& msg) const;
+  void publishReceivedPath(const nav_msgs::msg::Path& path);
+  void publishReceivedPath(const trajectory_tracker_msgs::msg::PathWithVelocity& path);
+  void publishRemainingPath();
 };
 
 }  // namespace trajectory_tracker

--- a/trajectory_tracker/src/tracker_node.cpp
+++ b/trajectory_tracker/src/tracker_node.cpp
@@ -407,7 +407,7 @@ void TrackerNode::cbTimer()
 
 void TrackerNode::cbOdomTimeout()
 {
-  std::lock_guard<std::mutex> lock(action_server_mutex_);
+  const std::lock_guard<std::mutex> lock(action_server_mutex_);
   RCLCPP_WARN_STREAM(get_logger(), "Odometry timeout. Last odometry stamp: " << prev_odom_stamp_.seconds());
   v_lim_.clear();
   w_lim_.clear();
@@ -435,7 +435,7 @@ void TrackerNode::cbOdomTimeout()
 void TrackerNode::control(const tf2::Stamped<tf2::Transform>& robot_to_odom, const Eigen::Vector3d& prediction_offset,
                           const double odom_linear_vel, const double odom_angular_vel, const double dt)
 {
-  std::lock_guard<std::mutex> lock(action_server_mutex_);
+  const std::lock_guard<std::mutex> lock(action_server_mutex_);
   trajectory_tracker_msgs::msg::TrajectoryTrackerStatus status;
   status.header.stamp = now();
   status.path_header = path_header_;
@@ -791,7 +791,7 @@ void TrackerNode::computeControl(std::shared_ptr<nav2_util::SimpleActionServer<A
   }
   RCLCPP_INFO(get_logger(), "Received a goal, begin computing control effort.");
   {
-    std::lock_guard<std::mutex> lock(action_server_mutex_);
+    const std::lock_guard<std::mutex> lock(action_server_mutex_);
     resetLatestStatus();
     if (action_server->get_current_goal()->path.poses.size() <= 1)
     {
@@ -804,7 +804,7 @@ void TrackerNode::computeControl(std::shared_ptr<nav2_util::SimpleActionServer<A
   }
 
   const bool goal_reached = spinActionServer(action_server);
-  std::lock_guard<std::mutex> lock(action_server_mutex_);
+  const std::lock_guard<std::mutex> lock(action_server_mutex_);
   publishZeroVelocity();
   if (goal_reached)
   {
@@ -924,7 +924,7 @@ bool TrackerNode::spinActionServer(const std::shared_ptr<nav2_util::SimpleAction
       }
     }
   }
-  catch (std::exception& e)
+  catch (const std::exception& e)
   {
     RCLCPP_ERROR(this->get_logger(), "Exception in action server: %s", e.what());
   }


### PR DESCRIPTION
- condition_variableを用いて、制御(control())とaction serverのfeedback送信が同期するようにした
- `/received_global_plan`は追従対象の座標が切り替わったときだけpublishするようにした
- '/tracking_path'にaction serverから受け取ったpathを書き戻し、~/statusと照合できるようにした
- 表示不要なメッセージをRCLCPP_DEBUGに変更