### PR TITLE
[trajectory_tracker] fix pivot turning algorithm

### DIFF
--- a/trajectory_tracker/src/tracker_node.cpp
+++ b/trajectory_tracker/src/tracker_node.cpp
@@ -664,14 +664,15 @@ TrackerNode::TrackingResult TrackerNode::getTrackingResult(const tf2::Stamped<tf
                i_nearest, i_local_goal, path_step_done_, lpath.size(), distance_remains, remain_local);
 
   bool arrive_local_goal(false);
-  bool in_place_turning = (vec[1] == 0.0 && vec[0] == 0.0);
+  const bool in_place_turning_at_last = (vec[1] == 0.0 && vec[0] == 0.0);
+  const bool in_place_turning_on_the_way = (std::abs(angle_remains) > stop_tolerance_ang_) && (v_lim_.get() == 0.0);
 
   TrackingResult result(trajectory_tracker_msgs::msg::TrajectoryTrackerStatus::FOLLOWING);
 
   // Stop and rotate
   const bool large_angle_error = std::abs(rotate_ang_) < M_PI && std::cos(rotate_ang_) > std::cos(angle_remains);
   if (large_angle_error || std::abs(remain_local) < stop_tolerance_dist_ || path_length < min_track_path_ ||
-      in_place_turning)
+      in_place_turning_at_last || in_place_turning_on_the_way)
   {
     if (large_angle_error)
     {
@@ -680,13 +681,13 @@ TrackerNode::TrackingResult TrackerNode::getTrackingResult(const tf2::Stamped<tf
                             angle_remains);
     }
 
-    if (path_length < min_track_path_ || std::abs(remain_local) < stop_tolerance_dist_ || in_place_turning)
+    if (path_length < min_track_path_ || std::abs(remain_local) < stop_tolerance_dist_ || in_place_turning_at_last)
     {
       angle_remains = trajectory_tracker::angleNormalized(-(it_local_goal - 1)->yaw_);
       if (it_local_goal != lpath.end())
         arrive_local_goal = true;
     }
-    if (path_length < stop_tolerance_dist_ || in_place_turning)
+    if (path_length < stop_tolerance_dist_ || in_place_turning_at_last)
       distance_remains = distance_remains_raw = 0.0;
 
     result.turning_in_place = true;


### PR DESCRIPTION
L672の`const bool large_angle_error` フラグは、ロボットの向きと経路の方向の差が、`rotate_ang_`パラメータの大きさより大きいかどうかを示す。このフラグがtrueであればロボットは目標前進速度を0とし、その場旋回を行う。

このフラグには2つの目的がある。
1つは、経路追従中に何らかの原因でロボットの向きと経路の方向が大きくずれた時、ロボットを一旦止めて追従をやり直すためである。もう1つは、ロボットがパス始点やローカルゴールでその場旋回するか、あるいは前進速度を出し始めるかどうかを判定するためである。
このように、2つの目的に共通のフラグが使われているため、パラメータ調整が困難である。すなわち、rotate_ang_を小さくすると、前者の機能の副作用(経路追従中にロボットが頻繁に停止してその場旋回を行ってしまう)が生じるが、大きくすると後者の機能の副作用(その場旋回の目標角度と角度差が大きいうちに前進速度が出始め、意図した経路をオーバーシュートしてしまう)が生じる。

このPRでは、新たに`in_place_turning_on_the_way`フラグを作成した。このフラグは、ロボットの目標前進速度が0の時、すなわち静止中もしくはその場旋回中に、ロボットの向きと経路の角度差が`stop_tolerance_ang_`パラメータより大きいかどうかを表しており、trueの時はその場旋回を行う。これにより、ロボットの向きと経路の角度差が`stop_tolerance_ang_`パラメータ未満になるまでロボットはその場旋回を続けるようになり、`rotate_ang_`を大きな値のままにできる。
`stop_tolerance_ang_`パラメータは、ゴール付近でロボットの目標前進・旋回速度を両方0にするために使われるパラメータであり、小さな値が設定される。今回追加した機能とその機能がバッティングすることはないと考えられる。