### PR TITLE
[trajectory_tracker] Keep path progress when the same path is re-published

### DIFF
--- a/trajectory_tracker/src/tracker_node.cpp
+++ b/trajectory_tracker/src/tracker_node.cpp
@@ -269,6 +269,26 @@ void TrackerNode::publishTrackingPath(const trajectory_tracker_msgs::msg::PathWi
 template <typename MSG_TYPE>
 void TrackerNode::cbPath(const MSG_TYPE& msg)
 {
+  // Preserve tracking progress across re-publications of the same path. Upstream
+  // may re-send the path every control cycle (e.g. a partial-path action re-ticked
+  // by a reactive behavior tree). Resetting path_step_done_ to 0 on every message
+  // then prevents the robot from advancing past an in-place turn at the path start:
+  // the turn cannot translate the robot, so the nearest point stays at the start
+  // and each reset undoes the commitment that would carry it past the turn -- it
+  // stays FOLLOWING at zero velocity (the gazebo playback freeze). Keep the
+  // previous progress index, but only when the new path still passes through the
+  // committed point (a re-publication/continuation); a genuinely new route does
+  // not, and resets to 0. The index is kept as-is rather than re-located to the
+  // nearest point, because near an in-place turn the path points are clustered and
+  // the nearest match could fall before the turn, losing the commitment.
+  const int64_t prev_path_step_done = path_step_done_;
+  const bool had_committed_progress =
+      (prev_path_step_done > 0 && prev_path_step_done < static_cast<int64_t>(path_.size()));
+  Eigen::Vector2d committed_position;
+  if (had_committed_progress)
+  {
+    committed_position = path_[prev_path_step_done].pos_;
+  }
   path_header_ = msg.header;
   is_path_updated_ = true;
   path_step_done_ = 0;
@@ -300,6 +320,16 @@ void TrackerNode::cbPath(const MSG_TYPE& msg)
       RCLCPP_ERROR_THROTTLE(get_logger(), *get_clock(), 1000, "path_velocity.velocity.x must be positive");
       path_.clear();
       return;
+    }
+  }
+  if (had_committed_progress && prev_path_step_done < static_cast<int64_t>(path_.size()))
+  {
+    // Keep the commitment only if the new path still passes near the committed
+    // point (continuation). A new route leaves it far away and stays reset.
+    constexpr double continuation_tolerance = 0.1;
+    if ((path_[prev_path_step_done].pos_ - committed_position).norm() < continuation_tolerance)
+    {
+      path_step_done_ = prev_path_step_done;
     }
   }
   publishTrackingPath(msg);


### PR DESCRIPTION
## 概要

`cbPath` が受信パスごとに `path_step_done_` を 0 にリセットしていたため、上流が同じパスを毎制御周期再送する状況（reactive behavior tree が partial-path action を毎周期 re-tick し、毎回新しい timestamp でパスを送る）で、パス開始点の in-place turn をロボットが永久に越えられなくなる不具合を修正する。

回転中はロボットが並進できず最近傍パス点が開始点に留まるため、毎周期のリセットが「回転を越えてパスを進める local-goal commitment」を打ち消し続け、tracker は FOLLOWING のままゼロ速度で停止し続ける（smilerobotics/v3 の gazebo playback CI が 8 コア runner の CPU 負荷下で flaky に固着する症状）。

## 修正

受信パスの先頭ポーズが現在のパスの先頭ポーズと一致する場合は同一パスの再送（継続）とみなし、`path_step_done_` を保持する（新パス長にクランプ）。先頭ポーズが変われば従来どおりリセット。`findNearest` が毎周期 progress を再アンカーするため、余計なリセットを除くだけで挙動は安全。

smilerobotics/v3 V3-7337。